### PR TITLE
Jenkinsfile: removing upstream trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 pipeline {
   agent { label 'ubuntu-18.04' }
-  triggers { upstream( upstreamProjects: 'IncludeOS/IncludeOS/master, IncludeOS/IncludeOS/dev', threshold: hudson.model.Result.SUCCESS ) }
   options { checkoutToSubdirectory('src') }
   environment {
     CONAN_USER_HOME = "${env.WORKSPACE}"
@@ -29,9 +28,9 @@ pipeline {
       }
     }
     stage('Upload to bintray') {
+      when { branch 'master' }
       parallel {
         stage('Latest release') {
-          when { branch 'master' }
           steps {
             upload_package("$CHAN_LATEST")
           }


### PR DESCRIPTION
Removed upstream trigger of job
Added:
- when branch is master *always* upload to channel `latest` 
- when  release tag *also* upload to `stable` 
