### PR TITLE
Update vmrunner.py to use hvf backend if available

### DIFF
--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -19,6 +19,8 @@ import linecache
 import traceback
 import signal
 import psutil
+import platform
+
 from shutil import copyfile
 
 import vmrunner.validate_vm as validate_vm
@@ -447,6 +449,10 @@ class qemu(hypervisor):
             self.info("KVM OFF")
             return False
 
+    # Check if we should use the hvf accel (MacOS only)
+    def hvf_present(self):
+        return (platform.system() == "Darwin")
+
     # Start a process and preserve in- and output pipes
     # Note: if the command failed, we can't know until we have exit status,
     # but we can't wait since we expect no exit. Checking for program start error
@@ -578,6 +584,10 @@ class qemu(hypervisor):
         # TODO: sudo is only required for tap networking and kvm. Check for those.
         command = ["sudo", qemu_binary]
         if self._kvm_present: command.extend(["--enable-kvm"])
+
+        # If hvf is present, use it and enable cpu features (needed for rdrand/rdseed)
+        if self.hvf_present():
+            command.extend(["-accel","hvf","-cpu","host"])
 
         command += kernel_args
         command += disk_args + debug_args + net_args + mem_arg + mod_args


### PR DESCRIPTION
This is needed for rdrand/rdseed support.

Cherry picked from https://github.com/includeos/IncludeOS/commit/4b08df50bd96e6c7a149e61d1bee51e0f019536e

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>