### PR TITLE
Non conan, filter SeaBIOS control chars, detect reboots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,34 @@
 # vmrunner
-Utility for booting [IncludeOS](https://github.com/includeos/includeos) binaries
+Utilities for booting [IncludeOS](https://github.com/includeos/includeos) binaries
 
-### Configure Settings
+- `vmrunner.py` - a convenience wrapper around qemu, integrated with IncludeOS tools
+- `boot`        - a command line tool using vmrunner.py, that boots IncludeOS binaries with qemu
+- `grubify.sh`  - a script to create a bootable grub image from an IncludeOS binary
 
+
+## Installing
+Install python3 venv, `sudo apt install python3.12-venv` on ubuntu 24.24. Then create a venv:
 ```
-  conan config install https://github.com/includeos/conan_config.git
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
 ```
-
-##### View remote and profiles installed
-
-* Remotes:
+Consider adding `vmrunner/bin` to your path to make the `boot` command available everywhere:
 ```
-  conan remote list
-```
-You should have these:
+# For boot and tests to find vmrunner.py
+$ export INCLUDEOS_VMRUNNER=<absolute-path-to-vmrunner>
 
-```
-  includeos: https://api.bintray.com/conan/includeos/includeos [Verify SSL: True]
-  includeos-test: https://api.bintray.com/conan/includeos/test-packages [Verify SSL: True]
-```
+# For `boot` to be available anywhere
+$ export PATH=$INCLUDEOS_VMRUNNER/bin:$PATH
 
-* Profiles:
-
+# To make python3 from your venv be the first python, which will then start boot
+$ export PATH=$INCLUDEOS_VMRUNNER/venv/bin:$PATH
 ```
-  conan profile list
+If you've built a chainloader, boot might be faster as it can use qemu's `-kernel` argument and not spend time building a grub filesystem.
 ```
-
-
-### Build and run vmrunner
-
-```bash
-  mkdir build
-  cd build
-  conan create .. includeos/stable -pr <profile-name>
+$ export INCLUDEOS_CHAINLOADER=<your-includeos-chainloader-pkg>/bin/chainloader
 ```
+If you don't have a chainloader, use `boot -g <your binary>` to create a grub image. Requires `grub-pc` to be installed.
+
+## Note: conan / jenkins deprecated.
+The Conanfile / Jenkinsfile is no longer maintained and will probably be removed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ $ export PATH=$INCLUDEOS_VMRUNNER/bin:$PATH
 
 # To make python3 from your venv be the first python, which will then start boot
 $ export PATH=$INCLUDEOS_VMRUNNER/venv/bin:$PATH
+
+# To make the vmrunner.py module globally available to boot 
+$ export PYTHONPATH=$INCLUDEOS_VMRUNNER
 ```
 If you've built a chainloader, boot might be faster as it can use qemu's `-kernel` argument and not spend time building a grub filesystem.
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Utilities for booting [IncludeOS](https://github.com/includeos/includeos) binari
 
 
 ## Installing
-Install python3 venv, `sudo apt install python3.12-venv` on ubuntu 24.24. Then create a venv:
+Install python3 venv, `sudo apt install python3.12-venv` on Ubuntu 24.04. Then create a venv:
 ```
 $ python3 -m venv venv
 $ source venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vmrunner
-Utilities for booting [IncludeOS](https://github.com/includeos/includeos) binaries
+Utilities for booting [IncludeOS](https://github.com/includeos/includeos) binaries - _for testing and development only_. 
 
-- `vmrunner.py` - a convenience wrapper around qemu, integrated with IncludeOS tools
+- `vmrunner.py` - a convenience wrapper around qemu, used by IncludeOS integration tests
 - `boot`        - a command line tool using vmrunner.py, that boots IncludeOS binaries with qemu
 - `grubify.sh`  - a script to create a bootable grub image from an IncludeOS binary
 

--- a/bin/boot
+++ b/bin/boot
@@ -177,13 +177,6 @@ if (args.grub or args.grub_reuse):
 
     has_bootloader = True
 
-<<<<<<< HEAD
-=======
-# Skip starting a VM if we are only building
-if (args.build): exit(0);
-
-
->>>>>>> 2eb876f (boot: More error handling, expect grub image at cwd)
 if (not has_bootloader):
     vm.boot(timeout = None, multiboot = True, debug = args.debug, kernel_args = " ".join(args.vmargs), image_name = image_name)
 else:

--- a/bin/boot
+++ b/bin/boot
@@ -53,7 +53,7 @@ args = parser.parse_args()
 
 
 # Pretty printing from this command
-nametag = "<boot>"
+nametag = "<boot>    "
 INFO = color.INFO(nametag)
 
 # Override VM output prepension
@@ -68,7 +68,6 @@ if (args.verbose):
 # Avoid the verbose var to hang around next run
 elif "VERBOSE" in os.environ:
     del os.environ["VERBOSE"]
-
 
 # Note: importing vmrunner will make it start looking for VM's
 # vmrunner also relies on the verbose env var to be set on initialization
@@ -141,14 +140,14 @@ if args.bridge:
     subprocess.call("create_bridge.sh", shell=True)
 
 elif file_extension in image_extensions:
-    if VERB: print(INFO, "File extension recognized as bootable image")
+    if VERB: print(INFO, f"File extension '{file_extension}' recognized as bootable image")
     has_bootloader = True
 
 elif not file_extension:
     if VERB: print(INFO, "No file extension. Trying to boot as kernel")
 
 else:
-    if VERB: print(INFO, "Unrecognized file extension. Trying to boot as kernel")
+    if VERB: print(INFO, f"Unrecognized file extension '{file_extension}'. Trying to boot as kernel")
 
 if (args.grub or args.grub_reuse):
     print(INFO, "Creating GRUB image from ", args.vm_location)

--- a/bin/boot
+++ b/bin/boot
@@ -6,7 +6,6 @@ import sys
 import argparse
 import subprocess
 import shutil
-import re
 
 from vmrunner.prettify import color
 

--- a/bin/boot
+++ b/bin/boot
@@ -5,9 +5,16 @@ import os
 import sys
 import argparse
 import subprocess
+import shutil
 import re
 
 from vmrunner.prettify import color
+
+# Get the path to INCLUDEOS_VMRUNNER from the environment variable
+includeos_vmrunner = os.environ.get('INCLUDEOS_VMRUNNER')
+if not includeos_vmrunner:
+    print("Error: INCLUDEOS_VMRUNNER environment variable is not set.")
+    sys.exit(1)
 
 # Argparse
 parser = argparse.ArgumentParser(
@@ -123,6 +130,9 @@ vm.on_panic(lambda x: None, do_exit = False)
 
 file_extension = os.path.splitext(args.vm_location)[1]
 
+def is_executable(file_path):
+    return os.path.isfile(file_path) and os.access(file_path, os.X_OK)
+
 if (args.debug):
     print(INFO, "Booting in debug mode")
 
@@ -147,10 +157,33 @@ if (args.grub or args.grub_reuse):
     if args.grub_reuse:
         opts += "-u "
 
-    subprocess.call("grubify.sh " + opts + image_name, shell=True)
-    image_name = image_name + ".grub.img"
+    grubify_script = shutil.which("grubify.sh")
+    if not grubify_script:
+        print(f"Error: {grubify_script} not found or not executable.")
+        sys.exit(1)
+
+    if not os.access('.', os.W_OK):
+        print("Error: Cannot write to the current directory.")
+        sys.exit(1)
+
+    subprocess.call(grubify_script + " " + opts + image_name, shell=True)
+
+    base_image_name = os.path.basename(image_name)
+    image_name = os.path.join(os.getcwd(), base_image_name + ".grub.img")
+
+    if not os.path.exists(image_name):
+        print(f"Error: {image_name} does not exist.")
+        sys.exit(1)
+
     has_bootloader = True
 
+<<<<<<< HEAD
+=======
+# Skip starting a VM if we are only building
+if (args.build): exit(0);
+
+
+>>>>>>> 2eb876f (boot: More error handling, expect grub image at cwd)
 if (not has_bootloader):
     vm.boot(timeout = None, multiboot = True, debug = args.debug, kernel_args = " ".join(args.vmargs), image_name = image_name)
 else:

--- a/bin/grubify.sh
+++ b/bin/grubify.sh
@@ -46,7 +46,7 @@ shift $((OPTIND-1))
 [[ $1 ]] || usage
 
 KERNEL=$1
-DISK=${DISK-$KERNEL.grub.img}
+DISK=$(basename ${DISK-$KERNEL.grub.img})
 MOUNTDIR=${MOUNTDIR-/mnt}
 MOUNT_OPTS="rw"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+future
+jsonschema
+psutil

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -822,6 +822,9 @@ class vm(object):
         return self
 
     def flush(self):
+        if self._hyper._proc == None:
+            return
+        
         while self._exit_status == None and self.poll() == None:
 
                 try:

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -35,7 +35,12 @@ default_config = INCLUDEOS_VMRUNNER  + "/vmrunner/vm.vanilla.json"
 
 default_json = "./vm.json"
 #TODO check and verify only when needed
-chainloader = os.environ['INCLUDEOS_CHAINLOADER'] + "/chainloader"
+chainloader = os.environ.get('INCLUDEOS_CHAINLOADER')
+
+if chainloader:
+    chainloader = chainloader + "/chainloader"
+else:
+    chainloader = None
 
 # Provide a list of VM's with validated specs
 # (One default vm added at the end)
@@ -497,6 +502,10 @@ class qemu(hypervisor):
             if is_Elf64(image_name):
                 info ("Found 64-bit ELF, need chainloader" )
                 print("Looking for chainloader: ")
+                if chainloader == None or not os.path.isfile(chainloader):
+                    print(f"Error: couldn't find chainloader. Try -g for grub, or create an .img with vmbuild.")
+                    sys.exit(1)
+
                 print("Found", chainloader, "Type: ",  file_type(chainloader))
                 if not is_Elf32(chainloader):
                     print(color.WARNING("Chainloader doesn't seem to be a 32-bit ELF executable"))


### PR DESCRIPTION
- Add requirements.txt and non-conan instructions
- Add more error handling, especially for missing chainloader
- Make grubify produce images at cwd, not next to binary, to allow direct `boot` of nix read-only binaries.
- Filter out terminal control characters from SeaBIOS, which prevents us from detecting reboots
  - This has the nice side-effect of making your terminal not broken after running qemu
- Detect and warn about reboots

