### PR TITLE
Add support for qemu's -netdev bridge

### DIFF
--- a/vmrunner/vm.schema.json
+++ b/vmrunner/vm.schema.json
@@ -73,7 +73,7 @@
         "properties" : {
           "device" : { "type" : "string" },
           "name" : { "type" : "string" },
-          "backend" : { "enum" : ["tap", "user"], "default" : "tap" }
+          "backend" : { "enum" : ["tap", "user", "bridge"], "default" : "bridge" }
         },
 
         "required" : ["device"]

--- a/vmrunner/vm.userspace.json
+++ b/vmrunner/vm.userspace.json
@@ -1,6 +1,10 @@
 {
-  "description" : "Single virtio nic with vanilla cpu features",
+  "description" : "Single virtio nic with vanilla cpu features. Expects an ethernet bridge to be configured.",
   "net" : [
-    {"device" : "virtio", "backend" : "user" }
+    {
+      "device" : "virtio",
+      "backend" : "bridge",
+      "bridge" : "bridge43"
+    }
   ]
 }

--- a/vmrunner/vmrunner.py
+++ b/vmrunner/vmrunner.py
@@ -459,10 +459,15 @@ class qemu(hypervisor):
 
             if self._kvm_present:
                 netdev += ",vhost=on"
+
             netdev += ",script=" + qemu_ifup + ",downscript=" + qemu_ifdown
+
+        if backend == "bridge" and bridge == None:
+            bridge = "bridge43"
 
         if bridge:
             netdev = "bridge,id=" + if_name + ",br=" + bridge
+
 
         # Device - e.g. guest side of nic
         device += ",netdev=" + if_name


### PR DESCRIPTION
This makes it possible to run tests that require a network bridge without sudo, assuming the bridge is set up ahead of time. The bridge can be set up with `./bin/create_bridge.sh` which does require sudo, or also `boot --create-bridge` which wraps that script.

In addition to this `/etc/qemu/bridge.conf` must contain a line allowing qemu to create tap devices and attach them to the bridge:
```
$ cat /etc/qemu/bridge.conf 
allow bridge43
```

Finally, the qemu bridge helper needs sudo permissions:
```
sudo chmod u+s /usr/lib/qemu/qemu-bridge-helper
```

I would have preferred to get usermode networking to be our default, it does not seem to be possible to forward ports to IPv6 guests, which is required for e.g. the important UDP test. I tried this: 
```
qemu-system-x86_64   -kernel $(nix-build chainloader.nix) -initrd net_udp.elf.bin   -device virtio-net-pci,netdev=n0,mac=52:54:12:34:56:00   -netdev user,id=n0,ipv6-net=fe80::/64,ipv6-host=fe80::2,hostfwd=udp::4242-:4242   -m 128 -nographic 
```
Which correctly forwards the IPv4 traffic, but has no effect on IPv6.  Attempting to specify the IPv6 address within the `hostfwd` clause in various ways only resulted in failure to parse the address.

Taking this route we would have to modify a lot of our network tests to specify the concrete port mappings. Instead I think we'll create a few select smoke tests with only ipv4 that uses usermode networking and have those run in CI on every submit, leaving IPv6 testing for longer test rungs, e.g. nightly, on nodes we fully control.