### PR TITLE
More static analysis with pylint, fix all warnings and errors

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,12 +31,18 @@ pkgs.python3.pkgs.buildPythonPackage rec {
 
   nativeCheckInputs = [
     pkgs.shellcheck
+    pkgs.pylint
   ];
 
   checkPhase = ''
     for f in vmrunner/bin/{*.sh,qemu-ifup,qemu-ifdown}; do
       echo Checking "$f" with shellcheck
       shellcheck "$f"
+    done
+
+    for f in vmrunner/*.py; do
+      echo Checking $f with pylint
+      pylint --persistent no "$f"
     done
   '';
 

--- a/vmrunner/prettify.py
+++ b/vmrunner/prettify.py
@@ -1,10 +1,13 @@
-from __future__ import print_function
+""" pretty printer for vmrunner """
 
+# pylint: disable=invalid-name,line-too-long
+
+from __future__ import print_function
 from builtins import str
 from builtins import range
-from builtins import object
 
-class color(object):
+class color:
+    """ helper methods for colored vmrunner output """
 
     BLACK = "0"
     RED = "1"
@@ -48,63 +51,78 @@ class color(object):
 
     @staticmethod
     def code(fg = WHITE, bg = BLACK, style = NORMAL, fg_intensity = FG_NORMAL, bg_intensity = BG_NORMAL):
+        """ output ascii code for the specified colors and intensity """
         return  color.ESC + style + ";" +  fg_intensity + fg + ";" + bg_intensity + bg + "m"
 
     @staticmethod
     def WARNING(string):
+        """ display a warning message """
         return color.C_WARNING + "[ WARNING ] " + string.rstrip() + color.C_ENDC
 
     @staticmethod
     def FAIL(string):
+        """ display a failed message """
         return "\n" + color.C_FAILED + "[ FAIL ] " + string.rstrip() + color.C_ENDC + "\n"
 
     @staticmethod
     def EXIT_ERROR(tag, string):
+        """ display exit error """
         return "\n" + color.C_FAILED + "[ " + tag + " ] " + string.rstrip() + color.C_ENDC + "\n"
 
     @staticmethod
     def FAIL_INLINE():
+        """ display fail message inline """
         return '[ ' + color.C_WHITE_ON_RED + " FAIL " + color.C_ENDC + ' ]'
 
     @staticmethod
     def SUCCESS(string):
+        """ display success message """
         return "\n" + color.C_OKGREEN + "[ SUCCESS ] " + string + color.C_ENDC + "\n"
 
     @staticmethod
     def PASS(string):
+        """ display pass message """
         return "\n" + color.C_OKGREEN + "[ PASS ] " + string + color.C_ENDC + "\n"
 
     @staticmethod
     def PASS_INLINE():
+        """ dislpay pass message inline """
         return '[ ' + color.C_BLACK_ON_GREEN + " PASS " + color.C_ENDC + ' ]'
 
     @staticmethod
     def OK(string):
+        """ display ok message """
         return color.C_BLACK_ON_GREEN + "[ OK ] " + string + color.C_ENDC
 
     @staticmethod
     def INFO(string):
+        """ display info message """
         return color.C_OKBLUE + "* " + string + ": " + color.C_ENDC
 
     @staticmethod
     def SUBPROC(string):
+        """ display message to indicate subprocess """
         return color.C_GREEN + "> " + color.C_DARK_GRAY + string.rstrip() + color.C_ENDC
 
     @staticmethod
     def VM(string):
+        """ display output from VM """
         return color.VM_PREPEND + string
 
     @staticmethod
     def DATA(string):
+        """ display data without any prefix or color coding """
         return string + "\n"
 
     @staticmethod
     def HEADER(string):
+        """ show header """
         return str("\n"+color.C_HEAD + "{:=^80}" + color.C_ENDC).format(" " + string + " ")
 
 
     @staticmethod
     def color_test():
+        """ test color printer """
         for fg in range(0,8):
             for bg in range(0,8):
                 print(color.code(fg = str(fg), bg = str(bg)), "Color " , str(fg), color.C_ENDC)

--- a/vmrunner/validate_vm.py
+++ b/vmrunner/validate_vm.py
@@ -1,36 +1,39 @@
 #! /usr/bin/env python3
+""" validate VM configuration against schema """
+
+# pylint: disable=invalid-name
+
 from __future__ import print_function
-from builtins import str
-from jsonschema import Draft4Validator, validators
 
-# Make the validator fill in defaults from the schema
-# Fetched from:
-# http://python-jsonschema.readthedocs.io/en/latest/faq/
-def extend_with_default(validator_class):
-    validate_properties = validator_class.VALIDATORS["properties"]
-
-    def set_defaults(validator, properties, instance, schema):
-        for property, subschema in properties.items():
-            if "default" in subschema:
-                instance.setdefault(property, subschema["default"])
-
-        for error in validate_properties(
-            validator, properties, instance, schema,
-        ):
-            yield error
-
-    return validators.extend(
-        validator_class, {"properties" : set_defaults},
-    )
-
-import jsonschema
 import json
 import sys
 import os
 import glob
 
+from builtins import str
+from jsonschema import Draft4Validator, validators
+
+
+# Fetched from:
+# http://python-jsonschema.readthedocs.io/en/latest/faq/
+def extend_with_default(validator_class):
+    """ make the validator fill in defaults from the schema """
+    validate_properties = validator_class.VALIDATORS["properties"]
+
+    def set_defaults(validator_, properties, instance, schema):
+        for property_, subschema in properties.items():
+            if "default" in subschema:
+                instance.setdefault(property_, subschema["default"])
+
+        yield from validate_properties(
+            validator_, properties, instance, schema,
+        )
+
+    return validators.extend(
+        validator_class, {"properties" : set_defaults},
+    )
+
 vm_schema = None
-valid_vms = []
 verbose = False
 
 validator = extend_with_default(Draft4Validator)
@@ -39,20 +42,24 @@ package_path = os.path.dirname(os.path.realpath(__file__))
 default_schema = package_path + "/vm.schema.json"
 
 def load_schema(filename = default_schema):
-  global vm_schema
-  vm_schema = json.loads(open(filename).read());
-
+    """ load json schema from file """
+    global vm_schema # pylint: disable=global-statement
+    with open(filename, encoding="utf8") as f:
+        vm_schema = json.loads(f.read())
 
 def validate_vm_spec(filename):
+    """ validate vm spec against schema """
     vm_spec = None
 
     # Load and parse as JSON
     try:
-        vm_spec = json.loads(open(filename).read())
+        with open(filename, encoding="utf8") as f:
+            vm_spec = json.loads(f.read())
     except Exception as e:
-        raise Exception("JSON load / parse Error for " + filename + ": " + str(e))
+        raise Exception("JSON load / parse Error for " + filename + ": " + str(e)) from e # pylint: disable=broad-exception-raised
 
-    if (not vm_schema): load_schema()
+    if not vm_schema:
+        load_schema()
 
     # Validate JSON according to schema
     validator(vm_schema).validate(vm_spec)
@@ -60,28 +67,32 @@ def validate_vm_spec(filename):
     return vm_spec
 
 
-def load_config(path, verbose = verbose):
-    global valid_vms
-
+def load_config(path_, verbose_ = verbose):
+    """ load VM config from file """
     # Single JSON-file  must conform to VM-schema
-    if (os.path.isfile(path)):
-        return validate_vm_spec(path)
+    if os.path.isfile(path_):
+        return validate_vm_spec(path_)
 
     jsons = []
 
-    if (os.path.isdir(path)):
-        jsons = glob.glob(path + "/*.json")
+    if os.path.isdir(path_):
+        jsons = glob.glob(path_ + "/*.json")
         jsons.sort()
 
     # For several JSON-files, return the ones conforming to VM-schema
-    for json in jsons:
-        if verbose: print("\t*Validating ", json, ": ", end=' ')
+    valid_vms = []
+    for json_ in jsons:
+        if verbose_:
+            print("\t*Validating ", json_, ": ", end=' ')
         try:
-            spec = validate_vm_spec(json)
+            spec = validate_vm_spec(json_)
             valid_vms.append(spec)
-            if verbose: print("OK")
-        except Exception as e:
-            if verbose: print("FAIL " + str(e))
+            if verbose_:
+                print("OK")
+        except Exception as e: # pylint: disable=broad-exception-caught
+            if verbose_:
+                print("FAIL " + str(e))
+
     return valid_vms
 
 
@@ -89,4 +100,4 @@ if __name__ == "__main__":
     path = sys.argv[1] if len(sys.argv) > 1 else "."
     if not load_config(path):
         print("No valid config found")
-        exit(-1)
+        sys.exit(-1)


### PR DESCRIPTION
Adds `pylint` to the tests and fixes all reported errors. Some are also ignored 
as they seemed insignificant (e.g. too many parameters, too many branches
etc).

While many of the changes were mostly cosmetic to follow recent python
standards and adding docstrings, this also required some refactoring.

Of note:

- renamed boot() in hypervisor-classes to boot_in_hypervisor(). This is
  to make it easier to separate from the vm.boot() function, which has
  almost the same parameters, but isn't a subclass of hypervisor.
- boot_in_hypervisor() parameters varied between subclasses, which all
  inherited from hypervisor. Now they are the same everywhere.
- Solo5 super class now requires an enum in init to select spt/hvt. This
  may break something, but it's a cleaner solution than requiring the
  binary name as an additional parameter to boot_in_hypervisor(). It
  also looks like the old vm.__init__ may have failed to init solo5
  hvt/spt correctly.
- Many of the errors were due to local variables shadowing global
  variables. In most cases I just added a "_" suffix to avoid this.
- Removed python2 compatibility imports (future etc)

I have tested this with the test suite in the IncludeOS v0.16.0-release branch
and everything seems to be working fine. I have not tested other hypervisors
than qemu.