### PR TITLE
Search harder for INCLUDEOS_VMRUNNER and INCLUDEOS_CHAINLOADER paths

### DIFF
--- a/vmrunner/boot.py
+++ b/vmrunner/boot.py
@@ -13,12 +13,6 @@ import shutil
 
 from vmrunner.prettify import color
 
-# Get the path to INCLUDEOS_VMRUNNER from the environment variable
-includeos_vmrunner = os.environ.get('INCLUDEOS_VMRUNNER')
-if not includeos_vmrunner:
-    print("Error: INCLUDEOS_VMRUNNER environment variable is not set.")
-    sys.exit(1)
-
 # Argparse
 parser = argparse.ArgumentParser(
   description="Boot - Run IncludeOS services")

--- a/vmrunner/vm.userspace.json
+++ b/vmrunner/vm.userspace.json
@@ -1,10 +1,1 @@
-{
-  "description" : "Single virtio nic with vanilla cpu features. Expects an ethernet bridge to be configured.",
-  "net" : [
-    {
-      "device" : "virtio",
-      "backend" : "bridge",
-      "bridge" : "bridge43"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
Now that vmrunner is a python package we can use the metadata to find the script location. If `INCLUDEOS_VMRUNNER` is not set, this adds support for finding the location automatically.

If vmrunner is installed with nix, the chainloader will be in a path listed in the `propagatedBuildInputs` environment variable. This adds support for searching for `./bin/chainloader` in this path if `INCLUDEOS_CHAINLOADER` is not set.

With these changes vmrunner can be used from a nix shell without having to set the environment variables.


Tested with includeos' ./test.sh to verify that the tests still work with this change (without env variables)