### PR TITLE
Disable R0917 (too many positional arguments) in pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[MESSAGES CONTROL]
+# r0917 = too many positional arguments
+disable=r0917


### PR DESCRIPTION
Pylint 3.3 adds a new warning for too many positional arguments. There are a couple of functions in vmrunner that has more than 5 positional parameters (which is the default). This breaks the build in newer versions of nixpkgs (25.05+). I've disabled the warning for now.

https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-positional-arguments.html