### PR TITLE
Add flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+/result

--- a/boot.nix
+++ b/boot.nix
@@ -1,0 +1,45 @@
+{ pkgs, vmrunner }:
+
+let
+  mk = chainloader: { name ? "unikernel", extraFlags ? [], kvm ? false, cfg }:
+    pkgs.symlinkJoin {
+      name = "boot-${name}";
+      paths = [ vmrunner ];
+      buildInputs = [ pkgs.makeWrapper ];
+
+      postBuild = ''
+        wrapProgram $out/bin/boot \
+          --set INCLUDEOS_CHAINLOADER ${chainloader}/bin/ \
+          --add-flags "${builtins.concatStringsSep " " cfg.vm.args}" \
+          ${pkgs.lib.optionalString kvm "--add-flags --kvm"} \
+          ${pkgs.lib.optionalString (extraFlags != []) (
+            "--add-flags \"" + builtins.concatStringsSep " " extraFlags + "\""
+          )}
+      '';
+    };
+
+  mkBoot = chainloader: cfg:
+    rec {
+      run = mk chainloader {
+        name = "${cfg.name or "unikernel"}-run";
+        inherit cfg;
+      };
+
+      debug = mk chainloader {
+        name = "${cfg.name or "unikernel"}-debug";
+        extraFlags = [ "-d" ];
+        inherit cfg;
+      };
+
+      kvm = mk chainloader {
+        name = "${cfg.name or "unikernel"}-kvm";
+        kvm = true;
+        inherit cfg;
+      };
+
+      default = run;
+    };
+in
+{
+  mkBoot = mkBoot;
+}

--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,11 @@ pkgs.python3.pkgs.buildPythonPackage rec {
     psutil
   ];
 
+  propagatedBuildInputs = [
+    pkgs.file
+    pkgs.qemu
+  ];
+
   create_bridge = ./vmrunner/bin/create_bridge.sh;
 
   passthru = {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748026580,
+        "narHash": "sha256-rWtXrcIzU5wm/C8F9LWvUfBGu5U5E7cFzPYT1pHIJaQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "11cb3517b3af6af300dd6c055aeda73c9bf52c48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,26 +9,30 @@
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
+
       vmrunner = pkgs.callPackage ./default.nix {};
+
+      vmconfig = import ./vmconfig.nix { inherit pkgs; };
+      boot = import ./boot.nix { inherit pkgs vmrunner; };
+
+      mkBoot = chainloader:
+      { mem ? "128m" }:
+        let
+          cfg = vmconfig.mkConfig { inherit mem; };
+        in
+          boot.mkBoot chainloader { vm = cfg; };
+
     in {
       packages.${system}.default = vmrunner;
 
       devShells.${system}.default = import ./shell.nix { inherit pkgs; };
+
+      lib.${system}.mkBoot = mkBoot;
 
       apps.${system}.default = {
         type = "app";
         program = "${vmrunner}/bin/boot";
       };
 
-      lib.${system}.mkBoot = chainloader: { kvm ? false}: pkgs.symlinkJoin {
-        name = "boot-with-chainloader";
-        paths = [ vmrunner ];
-        buildInputs = [ pkgs.makeWrapper ];
-        postBuild = ''
-          wrapProgram $out/bin/boot \
-            --set INCLUDEOS_CHAINLOADER ${chainloader}/bin/ \
-            ${pkgs.lib.optionalString kvm "--add-flags --kvm"}
-        '';
-      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "A convenience wrapper around qemu for IncludeOS integration tests";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/25.05";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      vmrunner = pkgs.callPackage ./default.nix {};
+    in {
+      packages.${system}.default = vmrunner;
+
+      devShells.${system}.default = import ./shell.nix { inherit pkgs; };
+
+      apps.${system}.default = {
+        type = "app";
+        program = "${vmrunner}/bin/boot";
+      };
+
+      lib.${system}.mkBoot = chainloader: pkgs.symlinkJoin {
+        name = "boot-with-chainloader";
+        paths = [ vmrunner ];
+        buildInputs = [ pkgs.makeWrapper ];
+        postBuild = ''
+          wrapProgram $out/bin/boot \
+            --set INCLUDEOS_CHAINLOADER ${chainloader}/bin/
+        '';
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,14 @@
         program = "${vmrunner}/bin/boot";
       };
 
-      lib.${system}.mkBoot = chainloader: pkgs.symlinkJoin {
+      lib.${system}.mkBoot = chainloader: { kvm ? false}: pkgs.symlinkJoin {
         name = "boot-with-chainloader";
         paths = [ vmrunner ];
         buildInputs = [ pkgs.makeWrapper ];
         postBuild = ''
           wrapProgram $out/bin/boot \
-            --set INCLUDEOS_CHAINLOADER ${chainloader}/bin/
+            --set INCLUDEOS_CHAINLOADER ${chainloader}/bin/ \
+            ${pkgs.lib.optionalString kvm "--add-flags --kvm"}
         '';
       };
     };

--- a/vmconfig.nix
+++ b/vmconfig.nix
@@ -1,0 +1,24 @@
+{ pkgs }:
+
+let
+  memToMiB = mem:
+    let
+      g = builtins.match "^([0-9]+)[Gg]$" mem;
+      m = builtins.match "^([0-9]+)[Mm]$" mem;
+    in
+      if g != null then (builtins.fromJSON (builtins.head g)) * 1024
+      else if m != null then builtins.fromJSON (builtins.head m)
+      else throw "invalid mem: ${mem}";
+in
+{
+  mkConfig = { mem ? "128m" }:
+    let
+      mem' = memToMiB mem;
+      vmJson = pkgs.writeText "vm.json"
+        (builtins.toJSON { mem = mem'; });
+    in {
+      mem = mem';
+      inherit vmJson;
+      args = [ "-j" vmJson ];
+    };
+}


### PR DESCRIPTION
This PR adds flake support to vmrunner, which will allow [includeos/IncludeOS](https://github.com/includeos/IncludeOS) to implement their own flake natively.

Because `boot` itself is reliant on the chainloader being on path, and we can't know this until after a unikernel is built, we provide a `mkBoot` function which exposes the `INCLUDEOS_CHAINLOADER` variable to vmrunner. With this, we can expose `boot-unikernel` as a chainload-ready booter from the unikernel's side.

This doesn't change anything for non-flake users.

Minor:
- add `/result` to gitignore: this is the default output directory of nix.
- add missing runtime dependencies to `default.nix` (with flakes, these are actually necessary).